### PR TITLE
update compare_snr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.DS_Store
+input
+output
+trained_models
 __pycache__/
 *.pyc
 *.swp

--- a/configs/data.yaml
+++ b/configs/data.yaml
@@ -1,4 +1,4 @@
-exp_dir: "~/data/logs/diffusion/public/res_256_to_130/"
+exp_dir: "/Users/honghsilee/Documents/GitHub/dldegibbs/trained_models/res_256_to_100"
 
 train_data:
   train_data_dir: "/gpfs/data/cbi/shared/unpacked_imagenet/"

--- a/data/metrics.py
+++ b/data/metrics.py
@@ -1,6 +1,6 @@
 import numpy as np
 from skimage.metrics import structural_similarity
-from skimage.measure import compare_psnr
+from skimage.metrics import peak_signal_noise_ratio
 
 
 class MetricEval(object):
@@ -17,7 +17,7 @@ class MetricEval(object):
     @staticmethod
     def psnr(gt, pred):
         """ Compute Peak Signal to Noise Ratio metric (PSNR) """
-        return compare_psnr(gt, pred, data_range=gt.max())
+        return peak_signal_noise_ratio(gt, pred, data_range=gt.max())
 
     @staticmethod
     def ssim(gt, pred):


### PR DESCRIPTION
skimage.measure.compare_snr is replaced by skimage.metrics.peak_signal_noise_ratio in skimage >=1.6.0